### PR TITLE
A workaround for clang problem assembling startup_raw.S

### DIFF
--- a/grub-core/boot/i386/pc/startup_raw.S
+++ b/grub-core/boot/i386/pc/startup_raw.S
@@ -118,7 +118,16 @@ LOCAL (codestart):
 
 #include "../../../kern/i386/realmode.S"
 
+/*
+ *
+ * This is a workaround for clang adding a section containing only .addrsig
+ * Since clang itself is unable to assemble this pseudo-opcode, just replace
+ * it with .text
+ *
+ */
+#define addrsig text
 #include <rs_decoder.h>
+#undef addrsig
 
 	.text
 


### PR DESCRIPTION
Signed-off-by: Vladimir Serbinenko <phcoder@google.com>
Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>