### PR TITLE
Fix wimboot for x64 UEFI windows installer

### DIFF
--- a/grub-core/map/wimboot/init.c
+++ b/grub-core/map/wimboot/init.c
@@ -56,7 +56,7 @@
 /** bootmgfw.efi path within WIM */
 #ifdef GRUB_MACHINE_EFI
 #define WIM_BOOTMGR_PATH L"\\Windows\\Boot\\EFI\\bootmgfw.efi"
-#define WIM_BOOTMGR_NAME L"bootmgfw.efi"
+#define WIM_BOOTMGR_NAME L"" BOOT_FILE_NAME
 #else
 #define WIM_BOOTMGR_PATH L"\\Windows\\Boot\\PXE\\bootmgr.exe"
 #define WIM_BOOTMGR_NAME L"bootmgr.exe"


### PR DESCRIPTION
Currently wimboot does not seem to be working for booting windows 7 installer in EFI x64 mode. I'm using the following command:

    wimboot --gui @:boot.wim:/pathto/sources/boot.wim @:bcd:/pathto/boot/bcd @:boot.sdi:/pathto/boot/boot.sdi

This works in BIOS mode, but in EFI x64 it fails with this screen:

![grub-wimboot-failure](https://user-images.githubusercontent.com/842846/90820817-5b58a100-e308-11ea-95e5-958147687f8f.png)

The last version wimboot worked for me in EFI mode was 68596aea36cea22012f6d372fc3012b72a6a23d9, it stopped working at 30922b6e7b91c1b0b0dd3a392166e6a4a23b2633 where BIOS support was added. The only difference I found between the way bootmgfw.efi was loaded, was that BOOTX64.efi was passed as the name to `wim_add_file`.

Assuming this will fail for other EFI architectures, I changed WIM_BOOTMGR_NAME to match BOOT_FILE_NAME, though I only have tested in EFI x64.