### PR TITLE
Update list.c

### DIFF
--- a/grub-core/grubfm/list.c
+++ b/grub-core/grubfm/list.c
@@ -174,7 +174,7 @@ grubfm_enum_device_iter (const char *name, void *data)
           grub_strcmp (fs->name, "udf") == 0)
         grubfm_add_menu (title, "iso", NULL, src, 0);
       else
-        grubfm_add_menu (title, "hdd", NULL, src, 0);
+        grubfm_add_menu (title, "${thu}", NULL, src, 0);
       *found = 1;
       grub_free (title);
       grub_free (src);


### PR DESCRIPTION
The change made is ${thu}. Can we change this code in order to assign a usb icon to (hd0,msdos1) and (hd0,msdos2) in grubfm with the command, that is, when we boot from usb, the icon of the usb memory will be usb in the boot menu, and the icon of the hdd will be shown as hdd?